### PR TITLE
Fix typo

### DIFF
--- a/topics/go/README.md
+++ b/topics/go/README.md
@@ -212,7 +212,7 @@ Rules of Performance:
 
 **_"When we're computer programmers we're concentrating on the intricate little fascinating details of programming and we don't take a broad engineering point of view about trying to optimize the total system. You try to optimize the bits and bytes." - Tom Kurtz (inventor of BASIC)_**
 
-"I don't trust anything until it runs... In fact, I don't trust anything until it runs twice." - Andrew Gelman (one of the greatest living statistians at Columbia University).
+"I don't trust anything until it runs... In fact, I don't trust anything until it runs twice." - Andrew Gelman (one of the greatest living statisticians at Columbia University).
 
 #### 5) Micro-Optimizations
 


### PR DESCRIPTION
This revision fixes a typo, giving the properly spelling of "statistician".